### PR TITLE
refactor initialization api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const theme = {
 };
 
 export type Theme = typeof theme;
-export const { StyleSheet, ThemeProvider, useTheme } = Sugar.init<Theme>(theme);
+export const { StyleSheet, ThemeProvider, useTheme } = Sugar<Theme>(theme);
 
 export default StyleSheet;
 ```

--- a/build/Main.d.ts
+++ b/build/Main.d.ts
@@ -1,14 +1,12 @@
 /// <reference types="react" />
 import Sugar from './Sugar';
-export default class Main {
-    init<T>(theme: T): {
-        StyleSheet: Sugar<T>;
-        ThemeContext: import("react").Context<T>;
-        ThemeProvider: import("react").ComponentType<{
-            children: import("react").ReactNode;
-            sugar?: Sugar<T> | undefined;
-        }>;
-        useTheme: () => T;
-        withTheme: <P extends import("./type").ThemeProp<T>>(WrappedComponent: import("react").ComponentType<P>) => () => JSX.Element;
-    };
-}
+export default function Main<T>(theme: T): {
+    StyleSheet: Sugar<T>;
+    ThemeContext: import("react").Context<T>;
+    ThemeProvider: import("react").ComponentType<{
+        children: import("react").ReactNode;
+        sugar?: Sugar<T> | undefined;
+    }>;
+    useTheme: () => T;
+    withTheme: <P extends import("./type").ThemeProp<T>>(WrappedComponent: import("react").ComponentType<P>) => () => JSX.Element;
+};

--- a/build/Main.js
+++ b/build/Main.js
@@ -2,11 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const Sugar_1 = require("./Sugar");
 const Provider_1 = require("./Provider");
-class Main {
-    init(theme) {
-        const StyleSheet = new Sugar_1.default(theme);
-        const { ThemeContext, ThemeProvider, useTheme, withTheme } = Provider_1.themeCreator(StyleSheet, theme);
-        return { StyleSheet, ThemeContext, ThemeProvider, useTheme, withTheme };
-    }
+function Main(theme) {
+    const StyleSheet = new Sugar_1.default(theme);
+    const { ThemeContext, ThemeProvider, useTheme, withTheme } = Provider_1.themeCreator(StyleSheet, theme);
+    return { StyleSheet, ThemeContext, ThemeProvider, useTheme, withTheme };
 }
 exports.default = Main;

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -2,5 +2,4 @@ export * from './Constant';
 export * from './Provider';
 import Main from './Main';
 export { Main as Sugar };
-declare const _default: Main;
-export default _default;
+export default Main;

--- a/build/index.js
+++ b/build/index.js
@@ -15,4 +15,4 @@ __exportStar(require("./Constant"), exports);
 __exportStar(require("./Provider"), exports);
 const Main_1 = require("./Main");
 exports.Sugar = Main_1.default;
-exports.default = new Main_1.default();
+exports.default = Main_1.default;

--- a/example/style/index.tsx
+++ b/example/style/index.tsx
@@ -1,4 +1,4 @@
-import Sugar, { constants } from "react-native-sugar-style";
+import { Sugar, constants } from "react-native-sugar-style";
 
 const commonTheme = {
   ...constants,
@@ -45,6 +45,6 @@ export const {
   ThemeContext,
   useTheme,
   withTheme
-} = Sugar.init<Theme>(lightTheme);
+} = Sugar<Theme>(lightTheme);
 
 export default StyleSheet;

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6801,10 +6801,7 @@ react-native-screens@~2.15.0:
   integrity sha512-CagNf2APXkVoRlF3Mugr264FbKbrBg9eXUkqhIPVeZB8EsdS8XPrnt99yj/pzmT+yJMBY0dGrjXT8+68WYh6YQ==
 
 react-native-sugar-style@./../:
-  version "0.0.9"
-
-"react-native-sugar-style@file:./..":
-  version "0.0.9"
+  version "0.1.0"
 
 react-native-unimodules@~0.12.0:
   version "0.12.0"

--- a/lib/Main.ts
+++ b/lib/Main.ts
@@ -1,12 +1,11 @@
 import Sugar from './Sugar';
 import { themeCreator } from './Provider';
-export default class Main {
-  init<T>(theme: T) {
-    const StyleSheet = new Sugar<T>(theme);
-    const { ThemeContext, ThemeProvider, useTheme, withTheme } = themeCreator(
-      StyleSheet,
-      theme
-    );
-    return { StyleSheet, ThemeContext, ThemeProvider, useTheme, withTheme };
-  }
+
+export default function Main<T>(theme: T) {
+  const StyleSheet = new Sugar<T>(theme);
+  const { ThemeContext, ThemeProvider, useTheme, withTheme } = themeCreator(
+    StyleSheet,
+    theme
+  );
+  return { StyleSheet, ThemeContext, ThemeProvider, useTheme, withTheme };
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,4 +2,4 @@ export * from './Constant';
 export * from './Provider';
 import Main from './Main';
 export { Main as Sugar };
-export default new Main();
+export default Main;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sugar-style",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React Native Stylesheet alternative with theme support",
   "author": "mohit23x",
   "license": "MIT",


### PR DESCRIPTION
- this simplifies the initialization api now instead of using `Sugar.init()`  we can use  `Sugar()` directly.